### PR TITLE
fix: duplication of index content probably introduced by a merge

### DIFF
--- a/layouts/index.html.html
+++ b/layouts/index.html.html
@@ -1,4 +1,3 @@
 {{ define "main" }}
-  {{ .Content }}
   {{ partial "timeline.html" . }}
 {{ end }}


### PR DESCRIPTION
notices we were getting the same blurb form the root `_index.md` twice

@geeksforsocialchange/developers
