### PR TITLE
add category type to timeline item

### DIFF
--- a/assets/scss/_timeline.scss
+++ b/assets/scss/_timeline.scss
@@ -57,6 +57,16 @@
       display: inline-block;
     }
   }
+
+  &__type {
+    display: inline-block;
+    background-color: var(--type-color);
+    font-weight: bold;
+    color: white;
+    padding: 0.1em 0.3em;
+    text-transform: capitalize;
+    margin-top: var(--s1);
+  }
 }
 
 .timeline-navigation {

--- a/assets/scss/_vars.scss
+++ b/assets/scss/_vars.scss
@@ -22,6 +22,7 @@
   --color-transparent-white: #ffffff6e;
   --color-brown: #533131;
   --color-white: #ffffff;
+  --type-color: var(--color-brown);
 
   // dimensions
   --timeline-image-width: 482px;

--- a/layouts/partials/timeline.html
+++ b/layouts/partials/timeline.html
@@ -39,6 +39,11 @@
                   {{ end }}
                 {{ end }}
 								<div>{{ .Content }}</div>
+								{{ with $quote.Params.category}}
+									<div class="timeline__type">
+										{{ replace . "_" " " }}
+									</div>
+                {{ end }}
 							</div>
 						{{ end }}
 					</div>


### PR DESCRIPTION
Fixes #91 

## Description

- add a little content type badge to timeline items
- should be able to overright the `--type-color` with a class when we get to that

@geeksforsocialchange/developers
