### PR TITLE
add image_caption to lightbox views

### DIFF
--- a/assets/js/lightbox.js
+++ b/assets/js/lightbox.js
@@ -28,7 +28,7 @@ document.addEventListener("DOMContentLoaded", () => {
         '" alt="' +
         element.getAttribute("alt") +
         '" /></div><span class="lightbox__title">' +
-        title.substring(0, title.lastIndexOf(".")) +
+         element.getAttribute("data-caption")+
         "</span>";
       lightbox.style.display = "block";
     });

--- a/layouts/partials/timeline.html
+++ b/layouts/partials/timeline.html
@@ -36,6 +36,7 @@
                             src={{ .RelPermalink }} 
                             alt={{ $quote.Params.image_alt }} 
                             title={{ $originalImagePath }}
+														data-caption={{$quote.Params.image_caption}}
                           ></img>
                         </div>
                       {{ end }}


### PR DESCRIPTION
Fixes #59 

## Description

- add a `data-caption` attribute to the images
- a quick switch of attributes in the JS to populate the title part of the markup

@geeksforsocialchange/developers
