### PR TITLE
Add visitor counter

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -21,6 +21,13 @@
       resources.Fingerprint "sha256" }}
     <link rel="stylesheet" href="{{ $style.Permalink }}" />
 		{{partial "socialMeta.html" .}}
+    {{- if hugo.IsProduction }}
+      <script
+          defer
+          data-domain="towersoldham.uk"
+          src="https://plausible.io/js/plausible.js"
+      ></script>
+    {{- end }}
   </head>
   <body>
     <main>


### PR DESCRIPTION
Fixes #28 

## Description

- Adds plausible script tag into header, only runs in production

## Notes

I just put this together following the pattern in the GFSC website & from reading the plausible docs it sounds like the script just runs and captures the info that this site was visited, but am I missing an API key? Also we won't be able to test this until it's on the actual final domain, which is registered here as towersoldham.uk, so I'm making a new ticket for this so we remember.

@geeksforsocialchange/developers
