### PR TITLE
include links to external sources

### DIFF
--- a/layouts/partials/timeline.html
+++ b/layouts/partials/timeline.html
@@ -49,7 +49,16 @@
                       <div class="timeline__quote {{cond $withoutImage "timeline__quote--outlined" ""}}">
                         {{ .Content }}
                         {{ with $quote.Params.source}}
-                          <p class="timeline__quote-source">{{ . }}</p>
+                          {{ $source := . }}
+                          {{ if $quote.Params.link }}
+                            <p class="timeline__quote-source">
+                              <a href="{{ $quote.Params.link }}">
+                                {{ $source }}
+                              </a>
+                            </p>
+                          {{ else }}
+                            <p class="timeline__quote-source">{{ $source }}</p>
+                          {{ end }}
                         {{ end }}
                         {{ with $quote.Params.category}}
                           <div class="timeline__type">


### PR DESCRIPTION
Fixes #114 

## Description

- it links to a source if there's a link
- inherits link styling from elsewhere, this should be brown when my fonts PR #131 get's merged in.

## questions

Mostly for @undividual in the XD file I didn't see a distinct source / linked source style so I've just left the text decoration in as removing it is an accessibility issue and in this case it could be really annoying to have to guess which ones you can click and which you can't. If you want to come up with something snazzier let me know and I'll make amends.

@geeksforsocialchange/developers
