### PR TITLE
return filter ui to normal layout flow

### DIFF
--- a/assets/scss/_filter.scss
+++ b/assets/scss/_filter.scss
@@ -1,7 +1,6 @@
 .filter {
   background-color: var(--color-cream);
-  position: sticky;
-  top: 0;
+  position: relative;
   z-index: 200;
   display: flex;
   flex-direction: column;
@@ -98,7 +97,6 @@
   border: none;
   background-color: var(--color-cream);
   color: var(--color-brown);
-  // padding: var(--s-5) var(--s0);
   cursor: pointer;
   font-weight: 600;
 }


### PR DESCRIPTION
Fixes #164 

## Description

- filter ui is no longer sticky and acts like a static part of the page

@geeksforsocialchange/developers
