### PR TITLE
add skip-to-timeline link for keyboard / screen reader users

### DIFF
--- a/assets/scss/_utils.scss
+++ b/assets/scss/_utils.scss
@@ -6,3 +6,14 @@
   height: 1px;
   overflow: hidden;
 }
+.screen-reader-only--focus:focus {
+  background-color: var(--color-brown);
+  color: var(--color-white);
+  font-weight: 600;
+  height: max-content;
+  left: 50%;
+  padding: var(--s-1);
+  position: absolute;
+  top: auto;
+  width: max-content;
+}

--- a/layouts/index.html.html
+++ b/layouts/index.html.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+	<a class="screen-reader-only screen-reader-only--focus" href="#timeline">Skip to timeline</a>
   {{partial "header.html" .}}
   {{ partial "timeline-navigation.html" . }}
   {{ partial "filter.html" . }}

--- a/layouts/partials/timeline.html
+++ b/layouts/partials/timeline.html
@@ -3,7 +3,7 @@
 {{ $imageWidth := printf "%s%s" (strings.TrimSuffix "px" (string $.Site.Data.timeline.imageSize.width)) "x" }}
 {{ $quotes := $.Site.GetPage (path.Join "/timeline") }}
 
-<div class="timeline ">
+<div id="timeline" class="timeline ">
   {{ range $decades }}
     {{ $decade := (index . 0) }}
     {{ $decadeImage := index . 2 }}


### PR DESCRIPTION
Fixes #163 

## Description

- the homepage has a hidden link to skip to the timeline, hit tab to reveal it and enter to use it.

@geeksforsocialchange/developers
