### PR TITLE
use meaningful text on links to the about page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -6,4 +6,4 @@ subtitle:  'A history of Summervale and Crossbank'
 
 This site hosts a timeline of personal stories, news, and archival images, to allow you to explore this part of Oldham's history, as told by residents, neighbours, and those who passed through. It's arranged chronologically, to show the changing area through time, and follows the stories of those living in and around the towers. 
 
-Find out more about the project [here](/about)
+For more information visit the [about page](/about)

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,7 +2,7 @@
 	<div class="footer__content">
 		<div class="footer__about" >
 			<p class="footer__text">This project was made possible by the National Lottery Heritage Fund, with thanks to National Lottery Players. Find out more about the project here</p>
-			<p class="footer__text">Find out more about the project <a class="footer__link" href="/about">here</a></p>
+			<p class="footer__text">For more information visit the <a class="footer__link" href="/about">about page</a></p>
 		</div>
 		<a class="footer__logo" href="https://www.heritagefund.org.uk/" >
 			<img class="footer__logo__img" src="/the_towers_footer_Logo.png" alt="project logo showing funding from the lottery heritage fund" >


### PR DESCRIPTION
Fixes #161 

## Description

- add a better description of what the link does.
- link is not unique but it serves the same purpose, consider removing from one location if that is a priority over ease of navigation.

@geeksforsocialchange/developers
