### PR TITLE
make the copy share link message audible to screen readers

### DIFF
--- a/layouts/partials/timeline.html
+++ b/layouts/partials/timeline.html
@@ -92,4 +92,4 @@
   <div class="lightbox"></div>
 </div>
 
-<div class="flash_message">This is the flash</div>
+<div role="alert" class="flash_message">This is the flash</div>


### PR DESCRIPTION
Fixes #171 

## Description

- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Alert_Role#example_1_making_ready-made_content_inside_an_element_with_an_alert_role_visible

@geeksforsocialchange/developers
