### PR TITLE
fix line height on quotes

### DIFF
--- a/assets/scss/_timeline.scss
+++ b/assets/scss/_timeline.scss
@@ -131,7 +131,7 @@
 
   &__quote-source {
     font-weight: 700;
-    line-height: 2;
+    margin-top: 0.5rem;
   }
 
   &__type {


### PR DESCRIPTION
Fixes #88

## Description

- Quote linespacing fixed
- I think this is the last thing in the big list of things in this ticket to do aside from making the background of the quotes completely opaque. The background at the moment though is really really really faint (no more than a watermark) so I'm wondering if we should leave it? Let me know if you think different and I can change this as well

@geeksforsocialchange/developers
